### PR TITLE
Upgrade to latest authz Envoy.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,7 @@ bind(
     actual = "//external:ssl",
 )
 
-ENVOY_SHA = "522ab0cc82458e6c4d114b120a421015f333b518"  # Oct 31, 2017
+ENVOY_SHA = "4108baad790ce5c39034b6506edbeea52dbc2eee" # Jan 16, 2017
 
 git_repository(
     name = "envoy",

--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -189,7 +189,7 @@ class CheckData : public HttpCheckData,
 
   bool GetSourceIpPort(std::string* ip, int* port) const override {
     if (connection_) {
-      return Utils::GetIpPort(connection_->remoteAddress().ip(), ip, port);
+      return Utils::GetIpPort(connection_->remoteAddress()->ip(), ip, port);
     }
     return false;
   }
@@ -320,10 +320,10 @@ class CheckData : public HttpCheckData,
 
 class ReportData : public HttpReportData {
   const HeaderMap* headers_;
-  const AccessLog::RequestInfo& info_;
+  const Envoy::RequestInfo::RequestInfo& info_;
 
  public:
-  ReportData(const HeaderMap* headers, const AccessLog::RequestInfo& info)
+  ReportData(const HeaderMap* headers, const Envoy::RequestInfo::RequestInfo& info)
       : headers_(headers), info_(info) {}
 
   std::map<std::string, std::string> GetResponseHeaders() const override {
@@ -531,7 +531,7 @@ class Instance : public Http::StreamDecoderFilter,
 
   virtual void log(const HeaderMap* request_headers,
                    const HeaderMap* response_headers,
-                   const AccessLog::RequestInfo& request_info) override {
+                   const Envoy::RequestInfo::RequestInfo& request_info) override {
     ENVOY_LOG(debug, "Called Mixer::Instance : {}", __func__);
     if (!handler_) {
       if (request_headers == nullptr) {

--- a/src/envoy/mixer/tcp_filter.cc
+++ b/src/envoy/mixer/tcp_filter.cc
@@ -126,8 +126,8 @@ class TcpInstance : public Network::Filter,
     ENVOY_CONN_LOG(debug,
                    "Called TcpInstance onNewConnection: remote {}, local {}",
                    filter_callbacks_->connection(),
-                   filter_callbacks_->connection().remoteAddress().asString(),
-                   filter_callbacks_->connection().localAddress().asString());
+                   filter_callbacks_->connection().remoteAddress()->asString(),
+                   filter_callbacks_->connection().localAddress()->asString());
 
     handler_ = mixer_control_.controller()->CreateRequestHandler();
     if (state_ == State::NotStarted) {
@@ -186,7 +186,7 @@ class TcpInstance : public Network::Filter,
 
   bool GetSourceIpPort(std::string* str_ip, int* port) const {
     return Utils::GetIpPort(
-        filter_callbacks_->connection().remoteAddress().ip(), str_ip, port);
+        filter_callbacks_->connection().remoteAddress()->ip(), str_ip, port);
   }
   bool GetSourceUser(std::string* user) const {
     return Utils::GetSourceUser(&filter_callbacks_->connection(), user);


### PR DESCRIPTION
Couple of changes that we are pulling in:
* Even if the response back from the Authz Grpc server times-out, have the ability to deny (default) the request or accept it (using `fail_mode_allow`) bool config.
* Ability to adjust the grpc server callback timeout using `timeout_ms` setting.
* Increase the timeout setting s.t we ideally don't have to use the `timeout_ms` knob in the config. 
* Merge with upstream `envoyproxy/envoy`.

With this change the name of the filter is changed to **ext_authz**
The tcp filter config would be:
```json
        {
         "type": "read",
         "name": "ext_authz",
         "config": { "stat_prefix": "authz",
                     "grpc_cluster": { 
                                       "cluster_name": "authz_server",
                                       "timeout_ms": 250 ## Optional
                     },
                     "failure_mode_allow": true  ## Optional, Default FALSE.
                    }
        }
```
The HTTP Filter config would be:
```json
              {
               "type": "decoder",
               "name": "ext_authz",
               "config": {
                              "grpc_cluster": { 
                                                 "cluster_name": "authz_server",
                                                 "timeout_ms": 250 ## Optional
                            },
                           "failure_mode_allow": true ## Optional, Default FALSE.
                         }
              }
```