### PR TITLE
Make building of specific binaries configurable.

### DIFF
--- a/script/release-binary
+++ b/script/release-binary
@@ -35,47 +35,54 @@ gsutil stat "${DST}/${BINARY_NAME}" \
   && { echo 'Binary already exists'; exit 0; } \
   || echo 'Building a new binary.'
 
-# Build the release binary
-bazel build --config=release //src/envoy:envoy_tar
-BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
-cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
-sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
+if [ -n "${BUILD_ALPHA}" ]; then
+  # Build the release binary
+  bazel build --config=release //src/envoy:envoy_tar
+  BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
+  cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
+  sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
-# Copy it to the bucket.
-echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
-gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+  # Copy it to the bucket.
+  echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
+  gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+fi
 
-BINARY_NAME="istio-proxy-${SHA}.deb"
-SHA256_NAME="istio-proxy-${SHA}.sha256"
-bazel build --config=release //tools/deb:istio-proxy
-BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy.deb"
-cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
-sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
+if [ -n "${BUILD_PROXY_DEB}" ]; then
+  BINARY_NAME="istio-proxy-${SHA}.deb"
+  SHA256_NAME="istio-proxy-${SHA}.sha256"
+  bazel build --config=release //tools/deb:istio-proxy
+  BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy.deb"
+  cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
+  sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
-# Copy it to the bucket.
-echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
-gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+  # Copy it to the bucket.
+  echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
+  gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+fi
 
+if [ -n "${BUILD_DEBUG}" ]; then
+  # Build the debug binary
+  BINARY_NAME="envoy-debug-${SHA}.tar.gz"
+  SHA256_NAME="envoy-debug-${SHA}.sha256"
+  bazel build -c dbg //src/envoy:envoy_tar
+  BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
+  cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
+  sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
-# Build the debug binary
-BINARY_NAME="envoy-debug-${SHA}.tar.gz"
-SHA256_NAME="envoy-debug-${SHA}.sha256"
-bazel build -c dbg //src/envoy:envoy_tar
-BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
-cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
-sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
+  # Copy it to the bucket.
+  echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
+  gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+fi
 
-# Copy it to the bucket.
-echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
-gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+if [ -n "${BUILD_DEBUG_DEB}" ]; then
+  BINARY_NAME="istio-proxy-debug-${SHA}.deb"
+  SHA256_NAME="istio-proxy-debug${SHA}.sha256"
+  bazel build -c dbg //tools/deb:istio-proxy
+  BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy.deb"
+  cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
+  sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
-BINARY_NAME="istio-proxy-debug-${SHA}.deb"
-SHA256_NAME="istio-proxy-debug${SHA}.sha256"
-bazel build -c dbg //tools/deb:istio-proxy
-BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy.deb"
-cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
-sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
-
-# Copy it to the bucket.
-echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
-gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+  # Copy it to the bucket.
+  echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
+  gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+fi


### PR DESCRIPTION
To ease the burden on the CI system make the building of each binary configurable. Building all 4 is not required as we pull only two and when all 4 are build then the CI vm is running out of space. It will also save time.